### PR TITLE
feat(hot-update): short-circuit unchanged sources via hmrDiff

### DIFF
--- a/packages/vite-plugin-svelte/src/plugins/hot-update.js
+++ b/packages/vite-plugin-svelte/src/plugins/hot-update.js
@@ -1,6 +1,7 @@
 import { log } from '../utils/log.js';
 import { setupWatchers } from '../utils/watch.js';
 import { SVELTE_VIRTUAL_STYLE_ID_REGEX } from '../utils/constants.js';
+import * as svelte from '@rsvelte/compiler';
 
 /**
  * @param {import('../types/plugin-api.d.ts').PluginAPI} api
@@ -21,6 +22,16 @@ export function hotUpdate(api) {
 	 * @type {Map<string|null,string>}
 	 */
 	const transformResultCache = new Map();
+
+	/**
+	 * Cache of the previous `.svelte` source per file, keyed by absolute
+	 * filename. Used together with `@rsvelte/compiler`'s `hmrDiff` to
+	 * short-circuit hot updates when the source on disk is byte-identical
+	 * to the previous version (mtime touched but content unchanged).
+	 *
+	 * @type {Map<string,string>}
+	 */
+	const prevSrcCache = new Map();
 
 	/** @type {import('vite').Plugin} */
 	const plugin = {
@@ -67,6 +78,7 @@ export function hotUpdate(api) {
 
 		buildStart() {
 			transformResultCache.clear();
+			prevSrcCache.clear();
 		},
 
 		transform: {
@@ -80,6 +92,33 @@ export function hotUpdate(api) {
 			async handler(ctx) {
 				const svelteRequest = idParser(ctx.file, false, ctx.timestamp);
 				if (svelteRequest) {
+					// Fast path: compare the new `.svelte` source against the
+					// cached previous version. When the source is byte-identical
+					// (mtime changed but content didn't), skip the entire
+					// transform-and-compare pipeline below.
+					if (typeof svelte.hmrDiff === 'function') {
+						let nextSrc;
+						try {
+							nextSrc = await ctx.read();
+						} catch {
+							nextSrc = undefined;
+						}
+						if (typeof nextSrc === 'string') {
+							const prevSrc = prevSrcCache.get(svelteRequest.filename);
+							prevSrcCache.set(svelteRequest.filename, nextSrc);
+							if (prevSrc != null) {
+								const diff = svelte.hmrDiff(prevSrc, nextSrc);
+								if (diff && diff.change === 'unchanged') {
+									log.debug(
+										`skipping hot update for ${svelteRequest.id} because svelte source is byte-identical to previous version`,
+										undefined,
+										'hmr'
+									);
+									return [];
+								}
+							}
+						}
+					}
 					const { modules } = ctx;
 					const svelteModules = [];
 					const nonSvelteModules = [];


### PR DESCRIPTION
## Summary
- Adds a fast path at the top of `hotUpdate.handler`: read the new source via `ctx.read()`, compare against the cached previous source for this file using `@rsvelte/compiler`'s `hmrDiff` (the Rust NAPI export wired in rsvelte's `src/vps/hmr.rs`), and skip the rest of the pipeline when the source is byte-identical.
- Conservative: only acts on `unchanged`; `hot-update` / `full-reload` fall through to the existing output-diff path so compiler normalisation behaviour stays the same.
- Falls back gracefully when `hmrDiff` is not present on the imported binding — guarded by `typeof === 'function'`.

## Why
The JS reference always re-runs `transformRequest` and then compares the compiled output to decide whether to emit an HMR update. That roundtrip is wasted when the underlying `.svelte` file is byte-identical to its previous version on disk (mtime touched but content unchanged — common with editors that re-save without modification, or with watch tools that touch files).

## Test plan
- [ ] Manual: open a SvelteKit dev server, save a `.svelte` file without modifying it, confirm `vite-plugin-svelte:hot-update` logs the short-circuit message at debug level.
- [ ] No e2e/fixture coverage in this submodule for the hot-update plugin yet — guarded by the runtime `typeof` check so older `@rsvelte/compiler` versions stay working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)