### PR TITLE
fix: import compiler from @rsvelte/vite-plugin-svelte-native, not @rsvelte/compiler

### DIFF
--- a/packages/vite-plugin-svelte/package.json
+++ b/packages/vite-plugin-svelte/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/baseballyama/vite-plugin-svelte#readme",
   "dependencies": {
-    "@rsvelte/compiler": ">=0.1.0",
+    "@rsvelte/vite-plugin-svelte-native": ">=0.1.0",
     "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
     "deepmerge": "^4.3.1",
     "magic-string": "^0.30.21",

--- a/packages/vite-plugin-svelte/src/plugins/compile-module.js
+++ b/packages/vite-plugin-svelte/src/plugins/compile-module.js
@@ -1,5 +1,5 @@
 import { buildModuleIdFilter, buildModuleIdParser } from '../utils/id.js';
-import * as svelteCompiler from '@rsvelte/compiler';
+import * as svelteCompiler from '@rsvelte/vite-plugin-svelte-native';
 import { log, logCompilerWarnings } from '../utils/log.js';
 import { toRollupError } from '../utils/error.js';
 import { isSvelteWithAsync } from '../utils/svelte-version.js';
@@ -19,7 +19,7 @@ export function compileModule(api) {
 	let idParser;
 
 	/**
-	 * @type {import('@rsvelte/compiler').ModuleCompileOptions}
+	 * @type {import('@rsvelte/vite-plugin-svelte-native').ModuleCompileOptions}
 	 */
 	let staticModuleCompileOptions;
 
@@ -42,7 +42,7 @@ export function compileModule(api) {
 					return;
 				}
 				const filename = moduleRequest.filename;
-				/** @type {import('@rsvelte/compiler').CompileOptions} */
+				/** @type {import('@rsvelte/vite-plugin-svelte-native').CompileOptions} */
 				const compileOptions = {
 					...staticModuleCompileOptions,
 					dev: !this.environment.config.isProduction,
@@ -96,11 +96,11 @@ export function compileModule(api) {
 
 /**
  *
- * @param {import('@rsvelte/compiler').CompileOptions} compilerOptions
- * @return {import('@rsvelte/compiler').ModuleCompileOptions}
+ * @param {import('@rsvelte/vite-plugin-svelte-native').CompileOptions} compilerOptions
+ * @return {import('@rsvelte/vite-plugin-svelte-native').ModuleCompileOptions}
  */
 function filterNonModuleCompilerOptions(compilerOptions) {
-	/** @type {Array<keyof import('@rsvelte/compiler').ModuleCompileOptions>} */
+	/** @type {Array<keyof import('@rsvelte/vite-plugin-svelte-native').ModuleCompileOptions>} */
 	const knownModuleCompileOptionNames = ['dev', 'generate', 'filename', 'rootDir', 'warningFilter'];
 	if (isSvelteWithAsync) {
 		knownModuleCompileOptionNames.push('experimental');
@@ -108,7 +108,7 @@ function filterNonModuleCompilerOptions(compilerOptions) {
 	// not typed but this is temporary until svelte itself ignores CompileOptions passed to compileModule
 	const experimentalModuleCompilerOptionNames = ['async'];
 
-	/** @type {import('@rsvelte/compiler').ModuleCompileOptions} */
+	/** @type {import('@rsvelte/vite-plugin-svelte-native').ModuleCompileOptions} */
 	const filtered = filterByPropNames(compilerOptions, knownModuleCompileOptionNames);
 	if (filtered.experimental) {
 		filtered.experimental = filterByPropNames(

--- a/packages/vite-plugin-svelte/src/plugins/preprocess.js
+++ b/packages/vite-plugin-svelte/src/plugins/preprocess.js
@@ -1,6 +1,6 @@
 import { toRollupError } from '../utils/error.js';
 import { mapToRelative } from '../utils/sourcemaps.js';
-import * as svelte from '@rsvelte/compiler';
+import * as svelte from '@rsvelte/vite-plugin-svelte-native';
 import { log } from '../utils/log.js';
 import { arraify } from '../utils/options.js';
 import fs from 'node:fs';
@@ -94,7 +94,7 @@ export function preprocess(api) {
  * @returns {import('../types/compile.d.ts').PreprocessSvelte}
  */
 function createPreprocessSvelte(options, resolvedConfig) {
-	/** @type {Array<import('@rsvelte/compiler').PreprocessorGroup>} */
+	/** @type {Array<import('@rsvelte/vite-plugin-svelte-native').PreprocessorGroup>} */
 	const preprocessors = arraify(options.preprocess);
 
 	for (const preprocessor of preprocessors) {

--- a/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/packages/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
-import * as svelte from '@rsvelte/compiler';
+import * as svelte from '@rsvelte/vite-plugin-svelte-native';
 import { log } from '../utils/log.js';
 import { toESBuildError, toRollupError } from '../utils/error.js';
 import { safeBase64Hash } from '../utils/hash.js';
@@ -190,7 +190,7 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 		// TODO ideally we'd be able to externalize prebundled styles too, but for now always put them in the js
 		css = 'injected';
 	}
-	/** @type {import('@rsvelte/compiler').CompileOptions} */
+	/** @type {import('@rsvelte/vite-plugin-svelte-native').CompileOptions} */
 	const compileOptions = {
 		dev: true, // default to dev: true because prebundling is only used in dev
 		...options.compilerOptions,

--- a/packages/vite-plugin-svelte/src/preprocess.js
+++ b/packages/vite-plugin-svelte/src/preprocess.js
@@ -21,10 +21,10 @@ export const lang_sep = '.vite-preprocess';
 
 /**
  * @param {import('./public.d.ts').VitePreprocessOptions} [opts]
- * @returns {import('@rsvelte/compiler').PreprocessorGroup}
+ * @returns {import('@rsvelte/vite-plugin-svelte-native').PreprocessorGroup}
  */
 export function vitePreprocess(opts) {
-	/** @type {import('@rsvelte/compiler').PreprocessorGroup} */
+	/** @type {import('@rsvelte/vite-plugin-svelte-native').PreprocessorGroup} */
 	const preprocessor = { name: 'vite-preprocess' };
 	if (opts?.script === true) {
 		preprocessor.script = rolldownVersion ? viteScriptOxc().script : viteScript().script;
@@ -37,7 +37,7 @@ export function vitePreprocess(opts) {
 }
 
 /**
- * @returns {{ script: import('@rsvelte/compiler').Preprocessor }}
+ * @returns {{ script: import('@rsvelte/vite-plugin-svelte-native').Preprocessor }}
  */
 function viteScript() {
 	return {
@@ -67,7 +67,7 @@ function viteScript() {
 }
 
 /**
- * @returns {{ script: import('@rsvelte/compiler').Preprocessor }}
+ * @returns {{ script: import('@rsvelte/vite-plugin-svelte-native').Preprocessor }}
  */
 function viteScriptOxc() {
 	return {
@@ -101,12 +101,12 @@ function viteScriptOxc() {
 
 /**
  * @param {import('vite').ResolvedConfig | import('vite').InlineConfig} config
- * @returns {{ style: import('@rsvelte/compiler').Preprocessor }}
+ * @returns {{ style: import('@rsvelte/vite-plugin-svelte-native').Preprocessor }}
  */
 function viteStyle(config = {}) {
 	/** @type {Promise<CssTransform> | CssTransform} */
 	let cssTransform;
-	/** @type {import('@rsvelte/compiler').Preprocessor} */
+	/** @type {import('@rsvelte/vite-plugin-svelte-native').Preprocessor} */
 	const style = async ({ attributes, content, filename = '' }) => {
 		const ext = attributes.lang ? `.${attributes.lang}` : '.css';
 		if (attributes.lang && !isCSSRequest(ext)) return;
@@ -132,7 +132,7 @@ function viteStyle(config = {}) {
 }
 
 /**
- * @param {import('@rsvelte/compiler').Preprocessor} style
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Preprocessor} style
  * @param {import('vite').ResolvedConfig | import('vite').InlineConfig} config
  * @returns {Promise<CssTransform>}
  */

--- a/packages/vite-plugin-svelte/src/public.d.ts
+++ b/packages/vite-plugin-svelte/src/public.d.ts
@@ -1,5 +1,5 @@
 import type { InlineConfig, ResolvedConfig } from 'vite';
-import type { CompileOptions, Warning, PreprocessorGroup } from '@rsvelte/compiler';
+import type { CompileOptions, Warning, PreprocessorGroup } from '@rsvelte/vite-plugin-svelte-native';
 import type { Options as InspectorOptions } from '@sveltejs/vite-plugin-svelte-inspector';
 
 export type Options = Omit<SvelteConfig, 'vitePlugin'> & PluginOptionsInline;

--- a/packages/vite-plugin-svelte/src/types/compile.d.ts
+++ b/packages/vite-plugin-svelte/src/types/compile.d.ts
@@ -1,4 +1,4 @@
-import type { Processed, CompileResult } from '@rsvelte/compiler';
+import type { Processed, CompileResult } from '@rsvelte/vite-plugin-svelte-native';
 import type { SvelteRequest } from './id.d.ts';
 import type { ResolvedOptions } from './options.d.ts';
 import type { CustomPluginOptionsVite, Rollup } from 'vite';

--- a/packages/vite-plugin-svelte/src/types/log.d.ts
+++ b/packages/vite-plugin-svelte/src/types/log.d.ts
@@ -1,4 +1,4 @@
-import type { Warning } from '@rsvelte/compiler';
+import type { Warning } from '@rsvelte/vite-plugin-svelte-native';
 
 export interface LogFn extends SimpleLogFn {
 	(message: string, payload?: unknown, namespace?: string): void;

--- a/packages/vite-plugin-svelte/src/types/options.d.ts
+++ b/packages/vite-plugin-svelte/src/types/options.d.ts
@@ -1,4 +1,4 @@
-import type { CompileOptions } from '@rsvelte/compiler';
+import type { CompileOptions } from '@rsvelte/vite-plugin-svelte-native';
 import type { ViteDevServer } from 'vite';
 // eslint-disable-next-line n/no-missing-import
 import { VitePluginSvelteStats } from '../utils/vite-plugin-svelte-stats.js';

--- a/packages/vite-plugin-svelte/src/utils/compile.js
+++ b/packages/vite-plugin-svelte/src/utils/compile.js
@@ -1,4 +1,4 @@
-import * as svelte from '@rsvelte/compiler';
+import * as svelte from '@rsvelte/vite-plugin-svelte-native';
 import { safeBase64Hash } from './hash.js';
 import { log } from './log.js';
 
@@ -21,7 +21,7 @@ export function createCompileSvelte() {
 	return async function compileSvelte(svelteRequest, code, options, sourcemap) {
 		const { filename, normalizedFilename, cssId, ssr, raw } = svelteRequest;
 		const { emitCss = true } = options;
-		/** @type {import('@rsvelte/compiler').Warning[]} */
+		/** @type {import('@rsvelte/vite-plugin-svelte-native').Warning[]} */
 		const warnings = [];
 
 		if (options.stats) {
@@ -49,7 +49,7 @@ export function createCompileSvelte() {
 			}
 		}
 
-		/** @type {import('@rsvelte/compiler').CompileOptions} */
+		/** @type {import('@rsvelte/vite-plugin-svelte-native').CompileOptions} */
 		const compileOptions = {
 			...options.compilerOptions,
 			filename,
@@ -90,7 +90,7 @@ export function createCompileSvelte() {
 			finalCompileOptions.sourcemap = sourcemap;
 		}
 		const endStat = stats?.start(filename);
-		/** @type {import('@rsvelte/compiler').CompileResult} */
+		/** @type {import('@rsvelte/vite-plugin-svelte-native').CompileResult} */
 		let compiled;
 		try {
 			compiled = svelte.compile(finalCode, { ...finalCompileOptions, filename });

--- a/packages/vite-plugin-svelte/src/utils/error.js
+++ b/packages/vite-plugin-svelte/src/utils/error.js
@@ -2,7 +2,7 @@ import { buildExtendedLogMessage } from './log.js';
 
 /**
  * convert an error thrown by svelte.compile to a RollupError so that vite displays it in a user friendly way
- * @param {import('@rsvelte/compiler').Warning & Error & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning & Error & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @returns {import('vite').Rollup.RollupError} the converted error
  */
@@ -29,7 +29,7 @@ export function toRollupError(error, options) {
 
 /**
  * convert an error thrown by svelte.compile to an esbuild PartialMessage
- * @param {import('@rsvelte/compiler').Warning & Error  & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning & Error  & {frame?: string}} error a svelte compiler error, which is a mix of Warning and an error
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @returns {any} the converted error as esbuild PartialMessage
  *
@@ -114,7 +114,7 @@ function couldBeFixedByCssPreprocessor(code) {
 }
 
 /**
- * @param {import('@rsvelte/compiler').Warning & Error} err a svelte compiler error, which is a mix of Warning and an error
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning & Error} err a svelte compiler error, which is a mix of Warning and an error
  * @param {string} originalCode
  * @param {import('../public.d.ts').Options['preprocess']} [preprocessors]
  */

--- a/packages/vite-plugin-svelte/src/utils/log.js
+++ b/packages/vite-plugin-svelte/src/utils/log.js
@@ -137,19 +137,19 @@ export const log = {
 
 /**
  * @param {import('../types/id.d.ts').SvelteRequest | import('../types/id.d.ts').SvelteModuleRequest} svelteRequest
- * @param {import('@rsvelte/compiler').Warning[]} warnings
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning[]} warnings
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  */
 export function logCompilerWarnings(svelteRequest, warnings, options) {
 	const { emitCss, onwarn, isBuild } = options;
 	const sendViaWS = !isBuild && options.experimental?.sendWarningsToBrowser;
 	let warn = isBuild ? warnBuild : warnDev;
-	/** @type {import('@rsvelte/compiler').Warning[]} */
+	/** @type {import('@rsvelte/vite-plugin-svelte-native').Warning[]} */
 	const handledByDefaultWarn = [];
 	const allWarnings = warnings?.filter((w) => !ignoreCompilerWarning(w, isBuild, emitCss));
 	if (sendViaWS) {
 		const _warn = warn;
-		/** @type {(w: import('@rsvelte/compiler').Warning) => void} */
+		/** @type {(w: import('@rsvelte/vite-plugin-svelte-native').Warning) => void} */
 		warn = (w) => {
 			handledByDefaultWarn.push(w);
 			_warn(w);
@@ -179,7 +179,7 @@ export function logCompilerWarnings(svelteRequest, warnings, options) {
 }
 
 /**
- * @param {import('@rsvelte/compiler').Warning} warning
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning} warning
  * @param {boolean} isBuild
  * @param {boolean} [emitCss]
  * @returns {boolean}
@@ -193,7 +193,7 @@ function ignoreCompilerWarning(warning, isBuild, emitCss) {
 
 /**
  *
- * @param {import('@rsvelte/compiler').Warning} warning
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning} warning
  * @returns {boolean}
  */
 function isNoScopableElementWarning(warning) {
@@ -202,7 +202,7 @@ function isNoScopableElementWarning(warning) {
 }
 
 /**
- * @param {import('@rsvelte/compiler').Warning} w
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning} w
  */
 function warnDev(w) {
 	if (w.filename?.includes('node_modules')) {
@@ -215,7 +215,7 @@ function warnDev(w) {
 }
 
 /**
- * @param {import('@rsvelte/compiler').Warning & {frame?: string}} w
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning & {frame?: string}} w
  */
 function warnBuild(w) {
 	if (w.filename?.includes('node_modules')) {
@@ -228,7 +228,7 @@ function warnBuild(w) {
 }
 
 /**
- * @param {import('@rsvelte/compiler').Warning} w
+ * @param {import('@rsvelte/vite-plugin-svelte-native').Warning} w
  */
 export function buildExtendedLogMessage(w) {
 	const parts = [];

--- a/packages/vite-plugin-svelte/src/utils/preprocess.js
+++ b/packages/vite-plugin-svelte/src/utils/preprocess.js
@@ -5,14 +5,14 @@ import { LINK_TRANSFORM_WITH_PLUGIN } from './constants.js';
  * @param {import('../types/options.d.ts').ResolvedOptions} options
  * @param {import('vite').ResolvedConfig} config
  * @returns {{
- * 	prependPreprocessors: import('@rsvelte/compiler').PreprocessorGroup[],
- * 	appendPreprocessors: import('@rsvelte/compiler').PreprocessorGroup[]
+ * 	prependPreprocessors: import('@rsvelte/vite-plugin-svelte-native').PreprocessorGroup[],
+ * 	appendPreprocessors: import('@rsvelte/vite-plugin-svelte-native').PreprocessorGroup[]
  * }}
  */
 function buildExtraPreprocessors(options, config) {
-	/** @type {import('@rsvelte/compiler').PreprocessorGroup[]} */
+	/** @type {import('@rsvelte/vite-plugin-svelte-native').PreprocessorGroup[]} */
 	const prependPreprocessors = [];
-	/** @type {import('@rsvelte/compiler').PreprocessorGroup[]} */
+	/** @type {import('@rsvelte/vite-plugin-svelte-native').PreprocessorGroup[]} */
 	const appendPreprocessors = [];
 
 	/** @type {import('vite').Plugin[]} */

--- a/packages/vite-plugin-svelte/src/utils/svelte-version.js
+++ b/packages/vite-plugin-svelte/src/utils/svelte-version.js
@@ -1,4 +1,4 @@
-import { VERSION } from '@rsvelte/compiler';
+import { VERSION } from '@rsvelte/vite-plugin-svelte-native';
 
 /**
  * @type {boolean}


### PR DESCRIPTION
## Summary

The `@rsvelte/vite-plugin-svelte` fork still imported the rsvelte compiler from `@rsvelte/compiler`. Per the integration plan in [`npm/vite-plugin-svelte-native/README.md`](https://github.com/baseballyama/rsvelte/tree/main/npm/vite-plugin-svelte-native) the fork's JS entrypoint is supposed to load the binding through `@rsvelte/vite-plugin-svelte-native` — the per-platform `.node` package set the rsvelte release pipeline ships.

The two packages publish **very different** runtimes:

- `@rsvelte/compiler` on npm is an older NAPI-wrapper layout that expects sibling `@rsvelte/binding-<triple>` packages. The rsvelte release pipeline no longer produces those siblings, so any consumer installing `@rsvelte/vite-plugin-svelte` from a registry pulls a `@rsvelte/compiler@0.2.0` whose required platform binding is missing → crash at the first preprocess call.
- `@rsvelte/vite-plugin-svelte-native` IS the current home of `compile()` / `compileModule()` / `preprocess()`, and now (after baseballyama/rsvelte#133) also exports the rich `CompileOptions` / `Warning` / `ModuleCompileOptions` / `PreprocessorGroup` / `Processed` types this fork uses in JSDoc.

## Changes

- All `import * as svelte from '@rsvelte/compiler'` / `import type { … } from '@rsvelte/compiler'` / `@type {import('@rsvelte/compiler')…}` switched to `@rsvelte/vite-plugin-svelte-native`. 13 files touched (`src/utils/*.js`, `src/plugins/*.js`, `src/preprocess.js`, `src/types/*.d.ts`, `src/public.d.ts`).
- `package.json`'s `dependencies` swaps `@rsvelte/compiler` for `@rsvelte/vite-plugin-svelte-native`.

No behavioral changes — same NAPI calls, same arguments, same result shape. Just the package name change.

## Companion PR

Depends on baseballyama/rsvelte#133 (which extends `@rsvelte/vite-plugin-svelte-native`'s `.d.ts` with the rich types this fork imports). With #133 merged + published, this fork installs cleanly and `tsc --noEmit` is clean.

Closes baseballyama/rsvelte#126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)